### PR TITLE
ci: align backend-node npm audit step with frontend-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,14 @@ jobs:
         timeout-minutes: 5
         run: npx playwright install --with-deps chromium
 
-      - name: Security (NPM Audit)
+      - name: Security (NPM Audit, advisory on PR)
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        working-directory: apps/backend-node
+        run: npm audit --audit-level=high --omit=dev
+
+      - name: Security (NPM Audit, blocking on non-PR)
+        if: github.event_name != 'pull_request'
         working-directory: apps/backend-node
         run: npm audit --audit-level=high --omit=dev
 


### PR DESCRIPTION
Align backend-node npm audit step with frontend-ci by introducing advisory step on pull requests, allowing dependency PRs to proceed while keeping non-PR audit strict.