### PR TITLE
fix(telemetry): make SimpleLogRecordProcessor log exporter compatible with newer @opentelemetry SDKs

### DIFF
--- a/apps/backend-node/src/core/telemetry.ts
+++ b/apps/backend-node/src/core/telemetry.ts
@@ -45,7 +45,9 @@ export async function initTelemetry(): Promise<void> {
     const nextSdk = new NodeSDK({
         serviceName: SERVICE_NAME,
         traceExporter: new ConsoleSpanExporter(),
-        logRecordProcessor: new SimpleLogRecordProcessor(compatLogExporter as any),
+        logRecordProcessor: new SimpleLogRecordProcessor(
+            compatLogExporter as unknown as Parameters<typeof SimpleLogRecordProcessor>[0]
+        ),
     });
 
     startupPromise = Promise.resolve(nextSdk.start())

--- a/apps/backend-node/src/core/telemetry.ts
+++ b/apps/backend-node/src/core/telemetry.ts
@@ -39,10 +39,13 @@ export async function initTelemetry(): Promise<void> {
         return;
     }
 
+    const consoleLogExporter = new ConsoleLogRecordExporter();
+    const compatLogExporter = Object.assign(consoleLogExporter, { exporter: consoleLogExporter });
+
     const nextSdk = new NodeSDK({
         serviceName: SERVICE_NAME,
         traceExporter: new ConsoleSpanExporter(),
-        logRecordProcessor: new SimpleLogRecordProcessor(new ConsoleLogRecordExporter()),
+        logRecordProcessor: new SimpleLogRecordProcessor(compatLogExporter as any),
     });
 
     startupPromise = Promise.resolve(nextSdk.start())

--- a/apps/backend-node/src/core/telemetry.ts
+++ b/apps/backend-node/src/core/telemetry.ts
@@ -46,7 +46,7 @@ export async function initTelemetry(): Promise<void> {
         serviceName: SERVICE_NAME,
         traceExporter: new ConsoleSpanExporter(),
         logRecordProcessor: new SimpleLogRecordProcessor(
-            compatLogExporter as unknown as Parameters<typeof SimpleLogRecordProcessor>[0]
+            compatLogExporter as unknown as ConstructorParameters<typeof SimpleLogRecordProcessor>[0]
         ),
     });
 


### PR DESCRIPTION
Ensure ConsoleLogRecordExporter works with both legacy and updated @opentelemetry/sdk-logs SimpleLogRecordProcessor signatures during dependency upgrades.