### PR TITLE
ci(dependabot): add auto-rebase strategy and limit open PRs to 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    rebase-strategy: "auto"
     labels:
       - "dependencies"
     commit-message:


### PR DESCRIPTION
Enable automatic rebase strategy for Dependabot PRs when main updates, and adjust open-pull-requests-limit to 5 to prevent CI queue congestion.