### PR TITLE
ci(dependabot): ignore semver-major updates and cap open PRs limit to 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     rebase-strategy: "auto"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
     commit-message:
@@ -29,6 +32,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
Strictly prevent Dependabot from creating automatic semver-major PRs and cap maximum open PRs limit to 2 to eliminate PR queue congestion.